### PR TITLE
Fix crash when a device doesn't have SIM card (or a long time without…

### DIFF
--- a/WonderPush/WonderPush.m
+++ b/WonderPush/WonderPush.m
@@ -1156,10 +1156,13 @@ static WPDialogButtonHandler *buttonHandler = nil;
 {
     CTTelephonyNetworkInfo *netinfo = [[CTTelephonyNetworkInfo alloc] init];
     CTCarrier *carrier = [netinfo subscriberCellularProvider];
-    if (carrier == nil) {
+    NSString *carrierName = [carrier carrierName];
+    
+    if (carrierName == nil) {
         return @"unknown";
     }
-    return [carrier carrierName];
+    
+    return carrierName;
 }
 
 +(NSString *) getVersionString


### PR DESCRIPTION
Crash à l'appel de la méthode `+ (void)setClientId:(NSString *)clientId secret:(NSString *)secret`

Le problème venait de la création d'un NSDictionary avec une valeur nulle, retournée par la méthode +`(NSString *) getCarrierName`

Un de mes devices de test n'avait pas de carte SIM (depuis longtemps ?) et le carrierName était donc nul.

Le problème est difficilement visible : lorsque l'on insère une carte SIM puis qu'on la déverrouille, le système mémorise les informations et les retournera même si l'on retire la carte SIM, et même après un redémarrage. 

Aperçu sur un iPhone 5S sous iOS 8.3.
