### PR TITLE
Fixed a crash when PATCH /installation fails and logs are enabled

### DIFF
--- a/WonderPush/WPJsonSyncInstallationCustom.m
+++ b/WonderPush/WPJsonSyncInstallationCustom.m
@@ -177,7 +177,7 @@ static NSMutableDictionary *instancePerUserId = nil;
                      WPLogDebug(@"Succeded to send diff for user %@: %@", _userId, responseJson);
                      onSuccess();
                  } else {
-                     WPLogDebug(@"Failed to send diff for user %@: error %@, response %@", error, response);
+                     WPLogDebug(@"Failed to send diff for user %@: error %@, response %@", _userId, error, response);
                      onFailure();
                  }
              }];

--- a/WonderPush/WPLog.h
+++ b/WonderPush/WPLog.h
@@ -17,5 +17,5 @@
 #import <Foundation/Foundation.h>
 
 void WPLogEnable(BOOL enabled);
-void WPLogDebug(NSString *format, ...);
-void WPLog(NSString *format, ...);
+void WPLogDebug(NSString *format, ...) NS_FORMAT_FUNCTION(1, 2);
+void WPLog(NSString *format, ...) NS_FORMAT_FUNCTION(1, 2);


### PR DESCRIPTION
A parameter was missing in a WLogDebug call in `-serverPatchCallbackWithDiff:onSuccess:`
This can be detected by adding the `NS_FORMAT_FUNCTION` annotation to WPLog and WPLogDebug declarations.