### PR TITLE
Forward a method to handle universal link in application delegate

### DIFF
--- a/WonderPush/WPAppDelegate.m
+++ b/WonderPush/WPAppDelegate.m
@@ -154,5 +154,18 @@ static BOOL _WPAppDelegateAlreadyRunning = NO;
     }
 }
 
+- (BOOL)application:(UIApplication *)application continueUserActivity:(NSUserActivity *)userActivity restorationHandler:(void (^)(NSArray * _Nullable))restorationHandler
+{
+    WPLogDebug(@"%@", NSStringFromSelector(_cmd));
+    BOOL rtn = YES;
+    if ([self.nextDelegate respondsToSelector:_cmd]) {
+        _WPAppDelegateAlreadyRunning = YES;
+        rtn = [self.nextDelegate application:application
+                        continueUserActivity:userActivity
+                          restorationHandler:restorationHandler];
+        _WPAppDelegateAlreadyRunning = NO;
+    }
+    return rtn;
+}
 
 @end


### PR DESCRIPTION
Wonderpush initialization caught `(BOOL)application:(UIApplication *)application continueUserActivity:(NSUserActivity *)userActivity restorationHandler:(void (^)(NSArray * _Nullable))restorationHandler` delegate method and does not forward it to application delegate.

