### PR TITLE
removed unnecessary private header

### DIFF
--- a/Sources/WonderPush/WPNetworkReachabilityManager.m
+++ b/Sources/WonderPush/WPNetworkReachabilityManager.m
@@ -23,7 +23,6 @@
 #if !TARGET_OS_WATCH
 
 #import <netinet/in.h>
-#import <netinet6/in6.h>
 #import <arpa/inet.h>
 #import <ifaddrs.h>
 #import <netdb.h>


### PR DESCRIPTION
Fixes #23 

Xcode 26.4 was unhappy with the private header and <netinet/in.h> already included it.  